### PR TITLE
Add Terms of Service page using existing ExpenseFlow layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,7 +285,7 @@
           <ul class="footer-links">
             <li><a href="#">About Us</a></li>
             <li><a href="#">Privacy Policy</a></li>
-            <li><a href="#">Terms of Service</a></li>
+            <li><a href="terms_service.html">Terms of Service</a></li>
             <li><a href="#">Contact</a></li>
           </ul>
         </div>

--- a/terms_service.html
+++ b/terms_service.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Terms of Service | ExpenseFlow</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <!-- Fonts & Icons -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+
+  <!-- SAME CSS FILE -->
+  <link rel="stylesheet" href="expensetracker.css">
+</head>
+
+<body>
+
+<!-- HEADER -->
+<header class="header">
+  <nav class="navbar">
+    <div class="nav-container">
+      <div class="nav-logo">
+        <i class="fas fa-wallet"></i>
+        <span>ExpenseFlow</span>
+      </div>
+
+      <div class="nav-menu">
+        <a href="index.html" class="nav-link">Dashboard</a>
+        <a href="#" class="nav-link">Analytics</a>
+        <a href="finance-tips.html" class="nav-link">Finance Tips</a>
+        <a href="terms_service.html" class="nav-link active">Terms of Service</a>
+        <a href="#" class="nav-link">Settings</a>
+      </div>
+    </div>
+  </nav>
+</header>
+
+<!-- MAIN -->
+<main class="main-content">
+
+  <!-- HERO -->
+  <section class="hero-section">
+    <h1 class="hero-title">Terms of Service</h1>
+    <p class="hero-subtitle">
+      Please read these terms carefully before using ExpenseFlow.
+    </p>
+  </section>
+
+  <div class="container">
+
+    <!-- SECTION 1 -->
+    <div class="balance-card">
+      <div class="balance-header">
+        <i class="fas fa-file-contract"></i>
+        <h4>1. Acceptance of Terms</h4>
+      </div>
+      <p class="hero-subtitle">
+        By accessing or using ExpenseFlow, you agree to be bound by these Terms of Service.
+        If you do not agree with any part of the terms, you must not use the platform.
+      </p>
+    </div>
+
+    <!-- SECTION 2 -->
+    <div class="balance-card">
+      <div class="balance-header">
+        <i class="fas fa-user-check"></i>
+        <h4>2. User Eligibility</h4>
+      </div>
+      <p class="hero-subtitle">
+        You must be at least 18 years old to use ExpenseFlow.
+        By using this service, you confirm that the information you provide is accurate and complete.
+      </p>
+    </div>
+
+    <!-- SECTION 3 -->
+    <div class="balance-card">
+      <div class="balance-header">
+        <i class="fas fa-list"></i>
+        <h4>3. User Responsibilities</h4>
+      </div>
+      <p class="hero-subtitle">
+        You are responsible for maintaining the confidentiality of your account
+        and for all activities that occur under your account.
+      </p>
+    </div>
+
+    <!-- SECTION 4 -->
+    <div class="balance-card">
+      <div class="balance-header">
+        <i class="fas fa-ban"></i>
+        <h4>4. Prohibited Activities</h4>
+      </div>
+      <p class="hero-subtitle">
+        You agree not to misuse the platform, attempt unauthorized access,
+        upload malicious content, or engage in any activity that disrupts services.
+      </p>
+    </div>
+
+    <!-- SECTION 5 -->
+    <div class="balance-card">
+      <div class="balance-header">
+        <i class="fas fa-scale-balanced"></i>
+        <h4>5. Disclaimer & Limitation of Liability</h4>
+      </div>
+      <p class="hero-subtitle">
+        ExpenseFlow is provided on an "as is" basis.
+        We are not responsible for financial losses, data inaccuracies,
+        or decisions made based on the information provided.
+      </p>
+    </div>
+
+    <!-- SECTION 6 -->
+    <div class="balance-card">
+      <div class="balance-header">
+        <i class="fas fa-power-off"></i>
+        <h4>6. Termination</h4>
+      </div>
+      <p class="hero-subtitle">
+        We reserve the right to suspend or terminate access to ExpenseFlow
+        if these terms are violated or misuse is detected.
+      </p>
+    </div>
+
+    <!-- SECTION 7 -->
+    <div class="balance-card">
+      <div class="balance-header">
+        <i class="fas fa-rotate"></i>
+        <h4>7. Changes to Terms</h4>
+      </div>
+      <p class="hero-subtitle">
+        ExpenseFlow may update these Terms of Service at any time.
+        Continued use of the platform means you accept the updated terms.
+      </p>
+    </div>
+
+    <!-- SECTION 8 -->
+    <div class="balance-card">
+      <div class="balance-header">
+        <i class="fas fa-envelope"></i>
+        <h4>8. Contact Information</h4>
+      </div>
+      <p class="hero-subtitle">
+        For any questions regarding these terms, please contact us through
+        the official support channels of ExpenseFlow.
+      </p>
+    </div>
+
+  </div>
+</main>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-container">
+    <div class="footer-section">
+      <div class="footer-logo">
+        <i class="fas fa-wallet"></i>
+        <span>ExpenseFlow</span>
+      </div>
+      <p>Smart money management made simple.</p>
+    </div>
+
+    <div class="footer-section">
+      <h4>Resources</h4>
+      <ul class="footer-links">
+        <li><a href="finance-tips.html">Finance Tips</a></li>
+        <li><a href="terms_service.html">Terms of Service</a></li>
+        <li><a href="#">Help Center</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="footer-bottom">
+    <div class="footer-container">
+      <p>&copy; 2026 ExpenseFlow. All rights reserved.</p>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
This pull request adds a dedicated Terms of Service page to ExpenseFlow.

Details:
- Created a new Terms of Service page (terms.html)
- Reused existing layout, navbar, footer, and CSS for consistency
- Clearly outlines user responsibilities, platform usage, and limitations
- Improves legal compliance and user transparency
- No changes to existing functionality or styles

This enhancement helps build user trust and aligns the platform with standard web practices.

<img width="1886" height="919" alt="Screenshot 2026-01-20 190615" src="https://github.com/user-attachments/assets/a11306f9-c427-414d-9608-8af8b979ab1c" />
<img width="1882" height="897" alt="Screenshot 2026-01-20 190633" src="https://github.com/user-attachments/assets/d7b2daa8-3fa7-492f-b2de-11387f363cdf" />

This PR#82  closes issue #68 