### PR TITLE
added Auto-label Issues and PRs Based on Content

### DIFF
--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -1,0 +1,25 @@
+name: Auto add ECWoC26 label to PRs
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add ECWoC26 label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ["ECWoC26"],
+            });


### PR DESCRIPTION
closes: #90 

what it does:
1. Automatically adds the ECWoC26 label when a new issue is opened
2. Automatically adds the ECWoC26 label when a new pull request is opened

@Renu-code123  please review it 