### PR TITLE
Add frontend password strength validation during signup

### DIFF
--- a/public/auth.js
+++ b/public/auth.js
@@ -42,6 +42,23 @@ if (registerForm) {
         const email = document.getElementById("email").value.trim();
         const password = document.getElementById("password").value.trim();
 
+        function isStrongPassword(password) {
+        return (
+            password.length >= 8 &&
+            /[A-Z]/.test(password) &&
+            /[a-z]/.test(password) &&
+            /[0-9]/.test(password) &&
+            /[^A-Za-z0-9]/.test(password)
+        );
+        }
+
+        if (!isStrongPassword(password)) {
+        alert(
+            "Password must be at least 8 characters long and include uppercase, lowercase, number, and special character."
+        );
+        return;
+        }
+
         try {
             const res = await fetch("/api/auth/register", {
                 method: "POST",


### PR DESCRIPTION
Summary

Adds basic password strength validation to the user registration flow to prevent weak passwords during signup.

Changes

Validates password strength in auth.js before submitting the register request

Rejects weak passwords and shows a validation message

No changes to login or backend logic

Password Requirements

Minimum 8 characters

Uppercase, lowercase, number, and special character required

Files Updated

auth.js

Issue Reference

Fixes #242