### PR TITLE
Improve password validation UX and disable Register button until password is strong

### DIFF
--- a/public/auth.js
+++ b/public/auth.js
@@ -1,4 +1,39 @@
+function getPasswordErrors(password) {
+    const errors = [];
+
+    if (password.length < 8) {
+        errors.push("at least 8 characters");
+    }
+    if (!/[A-Z]/.test(password)) {
+        errors.push("one uppercase letter");
+    }
+    if (!/[a-z]/.test(password)) {
+        errors.push("one lowercase letter");
+    }
+    if (!/[0-9]/.test(password)) {
+        errors.push("one number");
+    }
+    if (!/[^A-Za-z0-9]/.test(password)) {
+        errors.push("one special character");
+    }
+
+    return errors;
+}
+
+function showToast(message) {
+    const toast = document.getElementById("toast");
+    if (!toast) return;
+
+    toast.textContent = message;
+    toast.classList.add("show", "error");
+
+    setTimeout(() => {
+        toast.classList.remove("show", "error");
+    }, 3000);
+}
+
 const loginForm = document.getElementById("loginForm");
+
 if (loginForm) {
     loginForm.addEventListener("submit", async (e) => {
         e.preventDefault();
@@ -14,6 +49,7 @@ if (loginForm) {
                 },
                 body: JSON.stringify({ email, password }),
             });
+
             const data = await res.json();
             if (!res.ok) {
                 alert(data.message || "Login failed");
@@ -31,6 +67,51 @@ if (loginForm) {
     });
 }
 
+const passwordInput = document.getElementById("password");
+const registerBtn = document.getElementById("registerBtn");
+const passwordHint = document.getElementById("passwordHint");
+
+const rules = {
+    length: document.getElementById("rule-length"),
+    upper: document.getElementById("rule-upper"),
+    lower: document.getElementById("rule-lower"),
+    number: document.getElementById("rule-number"),
+    special: document.getElementById("rule-special"),
+};
+
+const updatePasswordUI = () => {
+    const password = passwordInput.value;
+
+    const checks = {
+        length: password.length >= 8,
+        upper: /[A-Z]/.test(password),
+        lower: /[a-z]/.test(password),
+        number: /[0-9]/.test(password),
+        special: /[^A-Za-z0-9]/.test(password),
+    };
+
+    let isValid = true;
+
+    Object.keys(checks).forEach((key) => {
+        if (!rules[key]) return;
+
+        if (checks[key]) {
+            rules[key].classList.add("valid");
+        } else {
+            rules[key].classList.remove("valid");
+            isValid = false;
+        }
+    });
+
+    passwordHint.style.display = isValid ? "none" : "block";
+    registerBtn.disabled = !isValid;
+};
+
+if (passwordInput && registerBtn) {
+    passwordInput.addEventListener("input", updatePasswordUI);
+    updatePasswordUI(); // run once on page load
+}
+
 // register user function
 const registerForm = document.getElementById("registerForm");
 
@@ -42,35 +123,13 @@ if (registerForm) {
         const email = document.getElementById("email").value.trim();
         const password = document.getElementById("password").value.trim();
 
-        function getPasswordErrors(password) {
-        const errors = [];
-
-        if (password.length < 8) {
-            errors.push("at least 8 characters");
-        }
-        if (!/[A-Z]/.test(password)) {
-            errors.push("one uppercase letter");
-        }
-        if (!/[a-z]/.test(password)) {
-            errors.push("one lowercase letter");
-        }
-        if (!/[0-9]/.test(password)) {
-            errors.push("one number");
-        }
-        if (!/[^A-Za-z0-9]/.test(password)) {
-            errors.push("one special character");
-        }
-
-        return errors;
-        }
-
         const passwordErrors = getPasswordErrors(password);
 
         if (passwordErrors.length > 0) {
-        showToast(
-            "Password must contain: " + passwordErrors.join(", ")
-        );
-        return;
+            showToast(
+                "Password must contain: " + passwordErrors.join(", ")
+            );
+            return;
         }
 
         try {
@@ -102,25 +161,14 @@ if (registerForm) {
 
 // logout function
 function logout() {
-  // Clear auth data
-  localStorage.removeItem('token');
-  localStorage.removeItem('user');
+    // Clear auth data
+    localStorage.removeItem('token');
+    localStorage.removeItem('user');
 
-  // Optional: clear everything
-  // localStorage.clear();
+    // Optional: clear everything
+    // localStorage.clear();
 
-  // Redirect to login
-  window.location.href = '/login.html';
+    // Redirect to login
+    window.location.href = '/login.html';
 }
 
-function showToast(message) {
-  const toast = document.getElementById("toast");
-  if (!toast) return;
-
-  toast.textContent = message;
-  toast.classList.add("show", "error");
-
-  setTimeout(() => {
-    toast.classList.remove("show", "error");
-  }, 3000);
-}

--- a/public/expensetracker.css
+++ b/public/expensetracker.css
@@ -6517,3 +6517,28 @@ button {
 .toast.error {
   border-left: 4px solid #ff6b6b;
 }
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.password-hint {
+  margin-top: 8px;
+  font-size: 0.85rem;
+  color: #cfd3ff;
+}
+
+.password-hint ul {
+  list-style: none;
+  padding-left: 0;
+  margin: 6px 0 0;
+}
+
+.password-hint li {
+  margin: 4px 0;
+}
+
+.password-hint li.valid {
+  display: none;
+}

--- a/public/signup.html
+++ b/public/signup.html
@@ -309,8 +309,18 @@
             <div class="form-group">
                 <label for="password" >Password:</label>
                <input type="password" id="password" placeholder="Password" required>
+               <div id="passwordHint" class="password-hint">
+                <strong>Password must include:</strong>
+                <ul>
+                  <li id="rule-length">At least 8 characters</li>
+                  <li id="rule-upper">One uppercase letter</li>
+                  <li id="rule-lower">One lowercase letter</li>
+                  <li id="rule-number">One number</li>
+                  <li id="rule-special">One special character</li>
+                </ul>
+              </div>
             </div>
-        <button type="submit" class="btn">Register</button>
+        <button type="submit" class="btn" id="registerBtn" disabled>Register</button>
          <p>Already have an account? <a href="login.html">Login here</a></p>
         </form>
 


### PR DESCRIPTION
What was changed
-Disabled the Register button until all password strength rules are satisfied
-Added real-time password validation feedback
-Each password rule is removed dynamically once it is satisfied
-Automatically hides the password hint when the password becomes strong
-Prevented UI overlap and layout shifts caused by strikethrough text

Why this change
-Previously, password validation feedback:
-Was only shown after form submission
-Used strikethrough styling, which caused text overlap and poor readability
-Did not clearly guide users on which requirements were still missing

This update improves usability by providing clear, incremental feedback and ensures users can only proceed when the password meets all requirements.

Result
-Cleaner and more intuitive signup experience
-No overlapping or cluttered UI
-Better accessibility and UX consistency with modern auth flows

Fixes #290 