### PR TITLE
feat: Add password visibility toggle to registration form

### DIFF
--- a/public/auth.js
+++ b/public/auth.js
@@ -172,3 +172,14 @@ function logout() {
     window.location.href = '/login.html';
 }
 
+const togglePassword = document.querySelector('#togglePassword');
+
+if (togglePassword && passwordInput) {
+    togglePassword.addEventListener('click', function (e) {
+        const type = passwordInput.getAttribute('type') === 'password' ? 'text' : 'password';
+        passwordInput.setAttribute('type', type);
+
+        this.classList.toggle('fa-eye');
+        this.classList.toggle('fa-eye-slash');
+    });
+}

--- a/public/expensetracker.css
+++ b/public/expensetracker.css
@@ -6542,3 +6542,24 @@ button {
 .password-hint li.valid {
   display: none;
 }
+
+.form-group > div {
+    position: relative;
+}
+
+#togglePassword {
+    position: absolute;
+    right: 15px;         
+    top: 50%;            
+    transform: translateY(-50%); 
+    cursor: pointer;
+    color: rgba(255, 255, 255, 0.6);
+    z-index: 10;     
+    margin: 0;           
+    display: inline-block; 
+    line-height: 1;     
+}
+
+#togglePassword:hover {
+    color: #fff;
+}

--- a/public/signup.html
+++ b/public/signup.html
@@ -308,7 +308,12 @@
             </div>
             <div class="form-group">
                 <label for="password" >Password:</label>
-               <input type="password" id="password" placeholder="Password" required>
+
+                <div style="position: relative;">
+                  <input type="password" id="password" placeholder="Password" required>
+                  <i class="far fa-eye" id="togglePassword"></i>
+                </div>
+               
                <div id="passwordHint" class="password-hint">
                 <strong>Password must include:</strong>
                 <ul>


### PR DESCRIPTION
## Description
This PR implements the password visibility toggle (eye icon) for the registration form, allowing users to switch between hidden and visible password text. This improves user experience by reducing typing errors during sign-up.

## Changes Made
- HTML: Added an eye icon wrapper to the password input field in `signup.html`.
- CSS: Added absolute positioning to align the eye icon correctly within the input field.
- JavaScript: Implemented logic in `auth.js` to toggle the input type between `password` and `text` and switch the icon classes.

## Screenshots
| Hide Password |
<img width="457" height="148" alt="hide" src="https://github.com/user-attachments/assets/664df372-b5e0-48db-889b-b39f2dd9b2fa" />

| Show Password | 
<img width="447" height="128" alt="show" src="https://github.com/user-attachments/assets/b4128201-64e7-484a-8ce2-2196b2cfe234" />

## Testing
- Verified that clicking the icon toggles the password visibility.
- Confirmed that password validation rules (length, special chars, etc.) still work correctly.
- Checked responsiveness on mobile and desktop views.

## Related Issue
Closes #302 