### PR TITLE
Add Scroll-to-Top button for better page navigation

### DIFF
--- a/expensetracker.css
+++ b/expensetracker.css
@@ -4313,6 +4313,46 @@ body {
   }
 }
 
+/* =========================
+   Scroll To Top Button
+   ========================= */
 
+.scroll-to-top {
+  position: fixed;
+  bottom: 30px;
+  right: 30px;
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  border: none;
+  background: linear-gradient(135deg, #64ffda, #48e0c1);
+  color: #0f0f23;
+  font-size: 1.2rem;
+  cursor: pointer;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  box-shadow: 0 8px 25px rgba(100, 255, 218, 0.35);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, opacity 0.25s ease;
+}
 
+.scroll-to-top:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 35px rgba(100, 255, 218, 0.5);
+}
+
+.scroll-to-top.show {
+  display: flex;
+}
+
+/* Mobile adjustment */
+@media (max-width: 768px) {
+  .scroll-to-top {
+    bottom: 20px;
+    right: 20px;
+    width: 46px;
+    height: 46px;
+  }
+}
 

--- a/index.html
+++ b/index.html
@@ -4257,5 +4257,32 @@ window.addEventListener("DOMContentLoaded", () => {
       }
     </script>
     </div> <!-- End #protectedContent -->
+    <!-- Scroll to Top Button -->
+    <button id="scrollToTopBtn" class="scroll-to-top" aria-label="Scroll to top">
+      <i class="fas fa-arrow-up"></i>
+    </button>
+    <script>
+      // Scroll to Top Button - Home Page Only
+      document.addEventListener("DOMContentLoaded", function () {
+        const scrollBtn = document.getElementById("scrollToTopBtn");
+      
+        if (!scrollBtn) return;
+      
+        window.addEventListener("scroll", () => {
+          if (window.scrollY > 300) {
+            scrollBtn.classList.add("show");
+          } else {
+            scrollBtn.classList.remove("show");
+          }
+        });
+      
+        scrollBtn.addEventListener("click", () => {
+          window.scrollTo({
+            top: 0,
+            behavior: "smooth"
+          });
+        });
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
### ✨ Scroll-to-Top Button (Home Page)

This PR adds a floating scroll-to-top button on the home page to improve navigation on long pages.

#### Features:
- Appears after scrolling down
- Smooth scroll back to top
- Responsive and UI-consistent
- Scoped only to the home page (index.html)

Fixes #528

This contribution is made under ECWoC'26.
