### PR TITLE
added dark light toggle on about us page

### DIFF
--- a/public/AboutUs.html
+++ b/public/AboutUs.html
@@ -50,6 +50,7 @@
           <a href="AboutUs.html" class="nav-link active">About Us</a>
           <a href="contact.html" class="nav-link">Contact</a>
           <a href="settings.html" class="nav-link">Settings</a>
+          <button id="themeToggle" class="theme-toggle">🌙</button>
         </div>
       </div>
     </nav>
@@ -231,6 +232,33 @@
 </button>
 <!-- Blue Cursor Trail -->
 <div class="circle-container" id="cursorTrail"></div>
+<script>
+
+const toggle = document.getElementById("themeToggle");
+
+// Toggle theme
+toggle.addEventListener("click", function(){
+
+document.body.classList.toggle("dark-mode");
+
+if(document.body.classList.contains("dark-mode")){
+localStorage.setItem("theme","dark");
+toggle.textContent="☀️";
+}
+else{
+localStorage.setItem("theme","light");
+toggle.textContent="🌙";
+}
+
+});
+
+// Load saved theme
+if(localStorage.getItem("theme") === "dark"){
+document.body.classList.add("dark-mode");
+toggle.textContent="☀️";
+}
+
+</script>
 <script>
 /* ============================= */
 /* 🔝 Scroll To Top Script */

--- a/public/aboutus.css
+++ b/public/aboutus.css
@@ -3,6 +3,10 @@
    HELP CENTER – SAFE UI ENHANCEMENTS
    (NO PARENT LAYOUT CHANGES)
 ========================= */
+body.dark-mode .feedback-form button{
+  background:#2563eb;
+  color:white;
+}
 html{
   scroll-behavior: smooth;
 }
@@ -653,4 +657,181 @@ html{
     width: 45px;
     height: 45px;
   }
+}/* Toggle Button */
+.theme-toggle{
+  background: none;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+  color: inherit;
+  margin-left: 15px;
+}
+
+/* Dark Mode Base */
+body.dark-mode{
+  background:#0f172a;
+  color:#e5e7eb;
+}
+
+/* Cards */
+body.dark-mode .balance-card{
+  background:#1e293b;
+  color:#e5e7eb;
+}
+
+/* Navbar */
+body.dark-mode .navbar{
+  background:#020617;
+}
+
+/* Footer */
+body.dark-mode .footer{
+  background:#020617;
+}
+
+/* Links */
+body.dark-mode a{
+  color:#38bdf8;
+}
+
+/* Inputs */
+body.dark-mode input,
+body.dark-mode textarea{
+  background:#1e293b;
+  color:white;
+  border:1px solid #334155;
+}
+
+/* Button */
+body.dark-mode button{
+  background:#2563eb;
+  color:white;
+}/* ============================= */
+/* GLOBAL LIGHT MODE (DEFAULT) */
+/* ============================= */
+
+body{
+  background:#ffffff;
+  color:#111827;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+/* Links */
+a{
+  color:#2563eb;
+}
+
+/* Navbar */
+.navbar{
+  background:#ffffff;
+  color:#111827;
+}
+
+/* Footer */
+.footer{
+  background:#f3f4f6;
+  color:#111827;
+}
+
+/* Cards */
+.balance-card{
+  background:#ffffff;
+  color:#111827;
+  border:1px solid #e5e7eb;
+}
+
+/* Inputs */
+input,
+textarea{
+  background:#ffffff;
+  color:#111827;
+  border:1px solid #d1d5db;
+}
+
+/* Buttons */
+button{
+  background:#6366f1;
+  color:white;
+}
+
+
+/* ============================= */
+/* DARK MODE */
+/* ============================= */
+
+body.dark-mode{
+  background:#0f172a;
+  color:#e5e7eb;
+}
+
+/* Navbar */
+body.dark-mode .navbar{
+  background:#020617;
+  color:#e5e7eb;
+}
+
+/* Footer */
+body.dark-mode .footer{
+  background:#020617;
+  color:#e5e7eb;
+}
+
+/* Cards */
+body.dark-mode .balance-card{
+  background:#1e293b;
+  color:#e5e7eb;
+  border:1px solid #334155;
+}
+
+/* Links */
+body.dark-mode a{
+  color:#38bdf8;
+}
+
+/* Inputs */
+body.dark-mode input,
+body.dark-mode textarea{
+  background:#1e293b;
+  color:#ffffff;
+  border:1px solid #334155;
+}
+
+/* Feedback button only */
+body.dark-mode .feedback-form button{
+  background:#2563eb;
+  color:white;
+}
+
+
+/* ============================= */
+/* THEME TOGGLE BUTTON */
+/* ============================= */
+
+.theme-toggle{
+  background:none;
+  border:none;
+  font-size:20px;
+  cursor:pointer;
+  color:inherit;
+  margin-left:15px;
+  transition:transform 0.2s ease;
+}
+
+.theme-toggle:hover{
+  transform:scale(1.15);
+}
+
+
+/* ============================= */
+/* SMOOTH TRANSITIONS */
+/* ============================= */
+
+body,
+.navbar,
+.footer,
+.balance-card,
+input,
+textarea,
+button{
+  transition: all 0.3s ease;
 }


### PR DESCRIPTION
## 🌙✨ Added Dark/Light Mode Toggle on About Us Page
## Overview

This PR introduces a Dark/Light theme toggle to the About Us page, allowing users to switch between light and dark themes for a better viewing experience.

## Key Changes

Added a theme toggle button in the navbar.

Implemented dark mode styling for key components including:

Page background

Navbar

Cards (balance-card)

Footer

Form inputs and buttons

Ensured smooth transitions between light and dark themes.

Implemented localStorage support to remember the user's theme preference across page reloads.

## Improvements

Enhances user accessibility and comfort, especially for low-light environments.

Maintains consistent styling with existing UI components.

No changes were made to the existing layout structure.

## Testing

Verified that theme toggling works correctly.

Confirmed theme preference persists after page refresh.

Checked compatibility across different screen sizes.

## Result

Users can now seamlessly switch between Dark Mode 🌙 and Light Mode ☀️ on the About Us page, improving the overall user experience.

This PR closes issue #996 

https://github.com/user-attachments/assets/a91f0f3d-fc38-451c-b049-79e1d59e2e15

