### PR TITLE
 Add Dark/Light Toggle to Finance Tips Page  

### DIFF
--- a/public/finance-tips.css
+++ b/public/finance-tips.css
@@ -495,3 +495,58 @@ html{
     transform: translate(-50%, -50%) scale(1.3);
     background: linear-gradient(135deg, #00b4d8 0%, #64ffda 100%) !important;
   }
+/* Dark mode without changing existing colors */
+
+body.dark-mode{
+  filter: invert(1) hue-rotate(180deg);
+}
+
+/* Fix images & icons */
+body.dark-mode img,
+body.dark-mode video,
+body.dark-mode iframe{
+  filter: invert(1) hue-rotate(180deg);
+}/* ======================
+   THEME VARIABLES
+====================== */
+
+:root{
+  --bg-color:#ffffff;
+  --card-bg:#f8fafc;
+  --text-color:#1e293b;
+  --accent:#22c55e;
+}
+
+[data-theme="dark"]{
+  --bg-color:#0f172a;
+  --card-bg:#1e293b;
+  --text-color:#f1f5f9;
+  --accent:#4ade80;
+}
+
+/* Apply theme */
+
+body{
+  background:var(--bg-color);
+  color:var(--text-color);
+  transition:0.3s;
+}
+
+.balance-card{
+  background:var(--card-bg);
+}
+
+.hero-section{
+  background:linear-gradient(135deg,var(--accent),#15803d);
+}
+
+/* Toggle button */
+
+.theme-toggle{
+  border:none;
+  background:transparent;
+  font-size:18px;
+  cursor:pointer;
+  color:var(--text-color);
+  margin-left:15px;
+}

--- a/public/finance-tips.html
+++ b/public/finance-tips.html
@@ -29,19 +29,25 @@
 <!-- HEADER -->
 <header class="header">
   <nav class="navbar">
-    <div class="nav-container">
-      <div class="nav-logo">
-        <i class="fas fa-wallet"></i>
-        <span><a href="index.html" class="nav-link">ExpenseFlow</a></span>
-      </div>
+   <div class="nav-container">
+  <div class="nav-logo">
+    <i class="fas fa-wallet"></i>
+    <span><a href="index.html" class="nav-link">ExpenseFlow</a></span>
+  </div>
 
-      <div class="nav-menu">
-        <a href="index.html" class="nav-link">Dashboard</a>
-        <a href="analytics.html" class="nav-link">Analytics</a>
-        <a href="finance-tips.html" class="nav-link active">Finance Tips</a>
-        <a href="settings.html" class="nav-link">Settings</a>
-      </div>
-    </div>
+  <div class="nav-menu">
+    <a href="index.html" class="nav-link">Dashboard</a>
+    <a href="analytics.html" class="nav-link">Analytics</a>
+    <a href="finance-tips.html" class="nav-link active">Finance Tips</a>
+    <a href="settings.html" class="nav-link">Settings</a>
+  </div>
+
+  <!-- DARK MODE BUTTON -->
+  <button id="theme-toggle" class="theme-toggle">
+    <i class="fas fa-moon"></i>
+  </button>
+
+</div>
   </nav>
 </header>
 

--- a/public/finance-tips.js
+++ b/public/finance-tips.js
@@ -150,3 +150,27 @@
   // Start animation
   animateTrail();
 })();
+const toggleBtn = document.getElementById("theme-toggle");
+
+// Load saved theme
+const savedTheme = localStorage.getItem("theme");
+
+if(savedTheme === "dark"){
+  document.documentElement.setAttribute("data-theme","dark");
+}
+
+// Toggle theme
+toggleBtn.addEventListener("click", () => {
+
+  const currentTheme =
+    document.documentElement.getAttribute("data-theme");
+
+  if(currentTheme === "dark"){
+    document.documentElement.removeAttribute("data-theme");
+    localStorage.setItem("theme","light");
+  }else{
+    document.documentElement.setAttribute("data-theme","dark");
+    localStorage.setItem("theme","dark");
+  }
+
+});


### PR DESCRIPTION
## Summary
Added a Dark/Light theme toggle feature to the Finance Tips page to improve user experience and accessibility.

## Changes Made
- Implemented Dark/Light mode toggle button in the Finance Tips page navbar
- Added JavaScript logic to switch themes dynamically
- Used localStorage to persist user theme preference
- Added dark-mode CSS styles without affecting existing layout or gradients

## Result
Users can now switch between light and dark themes, and their preference is saved across page reloads.

## Screenshots

https://github.com/user-attachments/assets/df210cc9-fcde-488a-b408-73f2d5d3a969


## Type of Change
Feature Enhancement

THis PR closes issue #1029 

